### PR TITLE
makefile: fix compilation and linkage

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 TARGET := chua_gen
-CFLAGS := -Wall -Werror -g -O0 
-LIBS   := -lglut -lGL
+CFLAGS := -Wall -Wextra -O2
+LIBS   := -lglut -lGL -lm
 
 SOURCES := $(wildcard *.c)
 OBJECTS := $(SOURCES:.c=.o)


### PR DESCRIPTION
- removed -Werror (gcc is stricter now), added -Wextra
- added '-lm' to link with libm
- changed -O0 for -O2
